### PR TITLE
オフライン環境でもビルドできるようにする

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 .DS_Store
 node_modules/
 npm-debug.log
+vendor
+.bundle
 
 *~
 

--- a/build-in-docker.sh
+++ b/build-in-docker.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 
+if ! (test -e node_modules && test -e vendor/bundle); then
+  docker run -t --rm -v $(pwd):/book vvakame/review:2.4 /bin/bash -ci "cd /book && ./setup.sh"
+fi
+
 # コマンド手打ちで作業したい時は以下の通り /book に pwd がマウントされます
 # docker run -i -t -v $(pwd):/book vvakame/review /bin/bash
 
-docker run -t --rm -v $(pwd):/book vvakame/review /bin/bash -ci "cd /book && ./setup.sh && npm run pdf"
+docker run -t --rm -v $(pwd):/book vvakame/review /bin/bash -ci "cd /book && npm run pdf"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
   },
   "scripts": {
     "global": "gem install bundler",
-    "postinstall": "bundle install",
     "check:prh": "prh --verify --verbose articles/*.re",
     "check": "npm run check:prh",
     "pdf": "grunt pdf",

--- a/setup.sh
+++ b/setup.sh
@@ -2,5 +2,7 @@
 
 git submodule init && git submodule update
 rm -rf node_modules
+rm -rf vendor/bundle
 # --unsafe-perm はrootでの実行時(= docker環境)で必要 非root時の挙動に影響なし
 npm install --unsafe-perm
+bundle install --path vendor/bundle


### PR DESCRIPTION
(docker-review のサンプルとしてこちらの雛形がリンクされていたので、こちらのリポジトリに PR を送っています。適切な向き先があれば出しなおしますのでご指摘ください 🙇)

現状のビルドスクリプトではコンテナのグローバル環境に直接 bundle install しているため、コンテナを立て直すたびに都度 bundle install しなおす必要があります。ほとんどの場合、ビルドに少し時間がかかる程度で特に問題ないのですが、この方法だとインターネット接続のある環境でしかビルドすることができず、外で原稿を試行錯誤したいときに不便なことに気づきました。

bundle のインストール先を（node_modules と同様に）ボリューム内にすることで、都度 setup.sh を実行しなくとも、初回だけ諸々のツールをインストールすれば以降はそのままビルドすることができ、オフラオイン環境でも試行錯誤できるようになります。

実際にビルドスクリプトを修正して、動作が確認できたため、パッチをお送りします。

よろしければお使いください 🙇 

----

EDIT: typo を修正しました